### PR TITLE
getServiceClient is not called correctly in getSesAsync

### DIFF
--- a/grails-app/services/grails/plugin/awssdk/AmazonWebService.groovy
+++ b/grails-app/services/grails/plugin/awssdk/AmazonWebService.groovy
@@ -204,7 +204,7 @@ class AmazonWebService {
     }
 
     AmazonSimpleEmailServiceAsyncClient getSesAsync(String region = '') {
-        getServiceClient('ses', region) as AmazonSimpleEmailServiceAsyncClient
+        getServiceClient('ses', region, true) as AmazonSimpleEmailServiceAsyncClient
     }
 
     AmazonSimpleEmailServiceClient getSes(String region = '') {


### PR DESCRIPTION
The getSesAsync method was returning a AmazonSimpleEmailServiceClient instance in stead of AmazonSimpleEmailServiceAsyncClient because of a missing async parameter
