### PR TITLE
Refactored AmazonWebService, added test tests, some bug fixes

### DIFF
--- a/grails-app/services/grails/plugin/awssdk/AmazonWebService.groovy
+++ b/grails-app/services/grails/plugin/awssdk/AmazonWebService.groovy
@@ -4,6 +4,7 @@ import com.amazonaws.AmazonWebServiceClient
 import com.amazonaws.ClientConfiguration
 import com.amazonaws.Protocol
 import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
 import com.amazonaws.services.autoscaling.AmazonAutoScalingAsyncClient
 import com.amazonaws.services.autoscaling.AmazonAutoScalingClient
 import com.amazonaws.services.cloudformation.AmazonCloudFormationAsyncClient
@@ -66,6 +67,35 @@ class AmazonWebService {
     private Map asyncClients = [:]
     private Map clients = [:]
     private Map transferManagers = [:]
+
+    private static final services = [
+        "autoScaling":              [endpoint: "autoscaling.%s.amazonaws.com", className: "com.amazonaws.services.autoscaling.AmazonAutoScalingClient"],
+        "cloudFormation":           [endpoint: "cloudformation.%s.amazonaws.com", className: "com.amazonaws.services.cloudformation.AmazonCloudFormationClient"],
+        "cloudFront":               [endpoint: "cloudfront.amazonaws.com", className: "com.amazonaws.services.cloudfront.AmazonCloudFrontClient"],
+        "cloudSearch":              [endpoint: "cloudsearch.%s.amazonaws.com", className: "com.amazonaws.services.cloudsearch.AmazonCloudSearchClient"],
+        "cloudWatch":               [endpoint: "monitoring.%s.amazonaws.com", className: "com.amazonaws.services.cloudwatch.AmazonCloudWatchClient"],
+        "dynamoDB":                 [endpoint: "dynamodb.%s.amazonaws.com", className: "com.amazonaws.services.dynamodb.AmazonDynamoDBClient"],
+        "ec2":                      [endpoint: "ec2.%s.amazonaws.com", className: "com.amazonaws.services.ec2.AmazonEC2Client"],
+        "elasticBeanstalk":         [endpoint: "elasticbeanstalk.%s.amazonaws.com", className: "com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalkClient"],
+        "elastiCache":              [endpoint: "elasticache.%s.amazonaws.com", className: "com.amazonaws.services.elasticache.AmazonElastiCacheClient"],
+        "elasticLoadBalancing":     [endpoint: "elasticloadbalancing.%s.amazonaws.com", className: "com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancingClient"],
+        "elasticMapReduce":         [endpoint: "elasticmapreduce.%s.amazonaws.com", className: "com.amazonaws.services.elasticmapreduce.AmazonElasticMapReduceClient"],
+        "elasticTranscoder":        [endpoint: "elastictranscoder.%s.amazonaws.com", className: "com.amazonaws.services.elastictranscoder.AmazonElasticTranscoderClient"],
+        "glacier":                  [endpoint: "glacier.%s.amazonaws.com", className: "com.amazonaws.services.glacier.AmazonGlacierClient"],
+        "iam":                      [endpoint: "iam.amazonaws.com", className: "com.amazonaws.services.identitymanagement.AmazonIdentityManagementClient"],
+        "importExport":             [endpoint: "importexport.amazonaws.com", className: "com.amazonaws.services.importexport.AmazonImportExportClient"],
+        "opsWorks":                 [endpoint: "opsworks.us-east-1.amazonaws.com", className: "com.amazonaws.services.opsworks.AWSOpsWorksClient"],
+        "rds":                      [endpoint: "rds.%s.amazonaws.com", className: "com.amazonaws.services.rds.AmazonRDSClient"],
+        "redshift":                 [endpoint: "redshift.us-east-1.amazonaws.com", className: "com.amazonaws.services.redshift.AmazonRedshiftClient"],
+        "route53":                  [endpoint: "route53.amazonaws.com", className: "com.amazonaws.services.route53.AmazonRoute53Client"],
+        "s3":                       [endpoint: "s3-%s.amazonaws.com", className: "com.amazonaws.services.s3.AmazonS3Client"],
+        "sdb":                      [endpoint: "sdb.%s.amazonaws.com", className: "com.amazonaws.services.simpledb.AmazonSimpleDBClient"],
+        "ses":                      [endpoint: "email.%s.amazonaws.com", className: "com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClient"],
+        "swf":                      [endpoint: "swf.%s.amazonaws.com", className: "com.amazonaws.services.simpleworkflow.AmazonSimpleWorkflowClient"],
+        "sns":                      [endpoint: "sns.%s.amazonaws.com", className: "com.amazonaws.services.sns.AmazonSNSClient"],
+        "sqs":                      [endpoint: "sqs.%s.amazonaws.com", className: "com.amazonaws.services.sqs.AmazonSQSClient"],
+        "storageGateway":           [endpoint: "storagegateway.%s.amazonaws.com", className: "com.amazonaws.services.storagegateway.AWSStorageGatewayClient"]
+    ]
 
     AmazonAutoScalingAsyncClient getAutoScalingAsync(region = '') {
         getServiceClient('autoScaling', region, true) as AmazonAutoScalingAsyncClient
@@ -139,11 +169,11 @@ class AmazonWebService {
         getServiceClient('elastiCache', region) as AmazonElastiCacheClient
     }
 
-    AmazonElasticLoadBalancingAsyncClient getElbAsync(region = '') {
+    AmazonElasticLoadBalancingAsyncClient getElasticLoadBalancingAsync(region = '') {
         getServiceClient('elasticLoadBalancing', region, true) as AmazonElasticLoadBalancingAsyncClient
     }
 
-    AmazonElasticLoadBalancingClient getElb(region = '') {
+    AmazonElasticLoadBalancingClient getElasticLoadBalancing(region = '') {
         getServiceClient('elasticLoadBalancing', region) as AmazonElasticLoadBalancingClient
     }
 
@@ -290,7 +320,7 @@ class AmazonWebService {
         grailsApplication.config.grails?.plugin?.awssdk
     }
 
-    private BasicAWSCredentials buildCredentials(defaultConfig, serviceConfig) {
+    private buildCredentials(defaultConfig, serviceConfig) {
         Map config = [
                 accessKey: defaultConfig.accessKey ?: '',
                 secretKey: defaultConfig.secretKey ?: ''
@@ -299,7 +329,14 @@ class AmazonWebService {
             if (serviceConfig.accessKey) config.accessKey = serviceConfig.accessKey
             if (serviceConfig.secretKey) config.secretKey = serviceConfig.secretKey
         }
-        new BasicAWSCredentials(config.accessKey, config.secretKey)
+
+        BasicAWSCredentials credentials = new BasicAWSCredentials(config.accessKey, config.secretKey)
+
+        if(!credentials.AWSAccessKeyId || !credentials.AWSSecretKey) {
+            return new DefaultAWSCredentialsProviderChain()
+        }
+
+        credentials
     }
 
     private ClientConfiguration buildClientConfiguration(defaultConfig, serviceConfig) {
@@ -334,318 +371,53 @@ class AmazonWebService {
     }
 
     private AmazonWebServiceClient getServiceClient(String service, String region = '', Boolean async = false) {
+        def serviceConfig = services[service]
+        def className = serviceConfig.className
+        def endpoint = serviceConfig.endpoint
+
+        if (async) {
+           className = className.replaceAll(/Client$/, 'AsyncClient')
+        }
+
         if (!region) {
             if (awsConfig[service]?.region) region = awsConfig[service].region
             else if (awsConfig?.region) region = awsConfig.region
             else region = DEFAULT_REGION
         }
 
-        if (async && !asyncClients[service]) asyncClients[service] = [:]
-        else if (!async && !clients[service]) clients[service] = [:]
+        def clientsCache = async ? asyncClients : clients
+        if (!clientsCache[service]) clientsCache[service] = [:]
 
-        if ((async && !asyncClients[service].hasProperty(region))
-                || (!async && !clients[service].hasProperty(region))) {
+        if (!clientsCache[service].containsKey(region)) {
             AmazonWebServiceClient client
-            BasicAWSCredentials credentials = buildCredentials(awsConfig, awsConfig[service])
+            def credentials = buildCredentials(awsConfig, awsConfig[service])
+
             ClientConfiguration configuration = buildClientConfiguration(awsConfig, awsConfig[service])
-            switch (service) {
-                case 'autoScaling':
-                    if (async) {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonAutoScalingAsyncClient(credentials)
-                        else client = new AmazonAutoScalingAsyncClient()
-                    } else {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonAutoScalingClient(credentials)
-                        else client = new AmazonAutoScalingClient()
-                    }
-                    client.configuration = configuration
-                    client.endpoint = "autoscaling.${region}.amazonaws.com"
-                    break
-                case 'cloudFormation':
-                    if (async) {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonCloudFormationAsyncClient(credentials)
-                        else client = new AmazonCloudFormationAsyncClient()
-                    } else {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonCloudFormationClient(credentials)
-                        else client = new AmazonCloudFormationClient()
-                    }
-                    client.configuration = configuration
-                    client.endpoint = "cloudformation.${region}.amazonaws.com"
-                    break
-                case 'cloudFront':
-                    if (async) {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonCloudFrontAsyncClient(credentials)
-                        else client = new AmazonCloudFrontAsyncClient()
-                    } else {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonCloudFrontClient(credentials)
-                        else client = new AmazonCloudFrontClient()
-                    }
-                    client.configuration = configuration
-                    client.endpoint = "cloudfront.amazonaws.com"
-                    break
-                case 'cloudSearch':
-                    if (async) {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonCloudSearchAsyncClient(credentials)
-                        else client = new AmazonCloudSearchAsyncClient()
-                    } else {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonCloudSearchClient(credentials)
-                        else client = new AmazonCloudSearchClient()
-                    }
-                    client.configuration = configuration
-                    client.endpoint = "cloudsearch.${region}.amazonaws.com"
-                    break
-                case 'cloudWatch':
-                    if (async) {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonCloudWatchAsyncClient(credentials)
-                        else client = new AmazonCloudWatchAsyncClient()
-                    } else {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonCloudWatchClient(credentials)
-                        else client = new AmazonCloudWatchClient()
-                    }
-                    client.configuration = configuration
-                    client.endpoint = "monitoring.${region}.amazonaws.com"
-                    break
-                case 'dynamoDB':
-                    if (async) {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonDynamoDBAsyncClient(credentials)
-                        else client = new AmazonDynamoDBAsyncClient()
-                    } else {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonDynamoDBClient(credentials)
-                        else client = new AmazonDynamoDBClient()
-                    }
-                    client.configuration = configuration
-                    client.endpoint = "dynamodb.${region}.amazonaws.com"
-                    break
-                case 'ec2':
-                    if (async) {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonEC2AsyncClient(credentials)
-                        else client = new AmazonEC2AsyncClient()
-                    } else {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonEC2Client(credentials)
-                        else client = new AmazonEC2Client()
-                    }
-                    client.configuration = configuration
-                    client.endpoint = "ec2.${region}.amazonaws.com"
-                    break
-                case 'elasticBeanstalk':
-                    if (async) {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AWSElasticBeanstalkAsyncClient(credentials)
-                        else client = new AWSElasticBeanstalkAsyncClient()
-                    } else {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AWSElasticBeanstalkClient(credentials)
-                        else client = new AWSElasticBeanstalkClient()
-                    }
-                    client.configuration = configuration
-                    client.endpoint = "elasticbeanstalk.${region}.amazonaws.com"
-                    break
-                case 'elastiCache':
-                    if (async) {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonElastiCacheAsyncClient(credentials)
-                        else client = new AmazonElastiCacheAsyncClient()
-                    } else {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonElastiCacheClient(credentials)
-                        else client = new AmazonElastiCacheClient()
-                    }
-                    client.configuration = configuration
-                    client.endpoint = "elasticache.${region}.amazonaws.com"
-                    break
-                case 'elasticLoadBalancing':
-                    if (async) {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonElasticLoadBalancingAsyncClient(credentials)
-                        else client = new AmazonElasticLoadBalancingAsyncClient()
-                    } else {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonElasticLoadBalancingClient(credentials)
-                        else client = new AmazonElasticLoadBalancingClient()
-                    }
-                    client.configuration = configuration
-                    client.endpoint = "elasticloadbalancing.${region}.amazonaws.com"
-                    break
-                case 'elasticMapReduce':
-                    if (async) {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonElasticMapReduceAsyncClient(credentials)
-                        else client = new AmazonElasticMapReduceAsyncClient()
-                    } else {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonElasticMapReduceClient(credentials)
-                        else client = new AmazonElasticMapReduceClient()
-                    }
-                    client.configuration = configuration
-                    client.endpoint = "elasticmapreduce.${region}.amazonaws.com"
-                    break
-                case 'elasticTranscoder':
-                    if (async) {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonElasticTranscoderAsyncClient(credentials)
-                        else client = new AmazonElasticTranscoderAsyncClient()
-                    } else {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonElasticTranscoderClient(credentials)
-                        else client = new AmazonElasticTranscoderClient()
-                    }
-                    client.configuration = configuration
-                    client.endpoint = "elastictranscoder.${region}.amazonaws.com"
-                    break
-                case 'glacier':
-                    if (async) {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonGlacierAsyncClient(credentials)
-                        else client = new AmazonGlacierAsyncClient()
-                    } else {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonGlacierClient(credentials)
-                        else client = new AmazonGlacierClient()
-                    }
-                    client.configuration = configuration
-                    client.endpoint = "glacier.${region}.amazonaws.com"
-                    break
-                case 'iam':
-                    if (async) {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonIdentityManagementAsyncClient(credentials)
-                        else client = new AmazonIdentityManagementAsyncClient()
-                    } else {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonIdentityManagementClient(credentials)
-                        else client = new AmazonIdentityManagementClient()
-                    }
-                    client.configuration = configuration
-                    client.endpoint = "iam.amazonaws.com"
-                    break
-                case 'importExport':
-                    if (async) {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonImportExportAsyncClient(credentials)
-                        else client = new AmazonImportExportAsyncClient()
-                    } else {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonImportExportClient(credentials)
-                        else client = new AmazonImportExportClient()
-                    }
-                    client.configuration = configuration
-                    client.endpoint = "importexport.amazonaws.com"
-                    break
-                case 'opsWorks':
-                    if (async) {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AWSOpsWorksAsyncClient(credentials)
-                        else client = new AWSOpsWorksAsyncClient()
-                    } else {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AWSOpsWorksClient(credentials)
-                        else client = new AWSOpsWorksClient()
-                    }
-                    client.configuration = configuration
-                    client.endpoint = "opsworks.us-east-1.amazonaws.com"
-                    break
-                case 'rds':
-                    if (async) {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonRDSAsyncClient(credentials)
-                        else client = new AmazonRDSAsyncClient()
-                    } else {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonRDSClient(credentials)
-                        else client = new AmazonRDSClient()
-                    }
-                    client.configuration = configuration
-                    client.endpoint = "rds.${region}.amazonaws.com"
-                    break
-                case 'redshift':
-                    if (async) {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonRedshiftAsyncClient(credentials)
-                        else client = new AmazonRedshiftAsyncClient()
-                    } else {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonRedshiftClient(credentials)
-                        else client = new AmazonRedshiftClient()
-                    }
-                    client.configuration = configuration
-                    client.endpoint = "redshift.us-east-1.amazonaws.com"
-                    break
-                case 'route53':
-                    if (async) {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonRoute53AsyncClient(credentials)
-                        else client = new AmazonRoute53AsyncClient()
-                    } else {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonRoute53Client(credentials)
-                        else client = new AmazonRoute53Client()
-                    }
-                    client.configuration = configuration
-                    client.endpoint = "route53.amazonaws.com"
-                    break
-                case 's3':
-                    if (async) throw new Exception("Sorry, there is no async client for AmazonS3")
-                    if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonS3Client(credentials)
-                    else client = new AmazonS3Client()
-                    client.configuration = configuration
-                    if (region == 'us' || region == DEFAULT_REGION) {
-                        client.endpoint = "s3.amazonaws.com"
-                    } else {
-                        client.endpoint = "s3-${region}.amazonaws.com"
-                    }
-                    break
-                case 'sdb':
-                    if (async) {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonSimpleDBAsyncClient(credentials)
-                        else client = new AmazonSimpleDBAsyncClient()
-                    } else {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonSimpleDBClient(credentials)
-                        else client = new AmazonSimpleDBClient()
-                    }
-                    client.configuration = configuration
-                    if (region == 'us-east-1') {
-                        client.endpoint = "sdb.amazonaws.com"
-                    } else {
-                        client.endpoint = "sdb.${region}.amazonaws.com"
-                    }
-                    break
-                case 'ses':
-                    if (async) {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonSimpleEmailServiceAsyncClient(credentials)
-                        else client = new AmazonSimpleEmailServiceAsyncClient()
-                    } else {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonSimpleEmailServiceClient(credentials)
-                        else client = new AmazonSimpleEmailServiceClient()
-                    }
-                    client.configuration = configuration
-                    client.endpoint = "email.${region}.amazonaws.com"
-                    break
-                case 'sns':
-                    if (async) {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonSNSAsyncClient(credentials)
-                        else client = new AmazonSNSAsyncClient()
-                    } else {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonSNSClient(credentials)
-                        else client = new AmazonSNSClient()
-                    }
-                    client.configuration = configuration
-                    client.endpoint = "sns.${region}.amazonaws.com"
-                    break
-                case 'sqs':
-                    if (async) {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonSQSAsyncClient(credentials)
-                        else client = new AmazonSQSAsyncClient()
-                    } else {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonSQSClient(credentials)
-                        else client = new AmazonSQSClient()
-                    }
-                    client.configuration = configuration
-                    client.endpoint = "sqs.${region}.amazonaws.com"
-                    break
-                case 'storageGateway':
-                    if (async) {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AWSStorageGatewayAsyncClient(credentials)
-                        else client = new AWSStorageGatewayAsyncClient()
-                    } else {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AWSStorageGatewayClient(credentials)
-                        else client = new AWSStorageGatewayClient()
-                    }
-                    client.configuration = configuration
-                    client.endpoint = "storagegateway.${region}.amazonaws.com"
-                    break
-                case 'swf':
-                    if (async) {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonSimpleWorkflowAsyncClient(credentials)
-                        else client = new AmazonSimpleWorkflowAsyncClient()
-                    } else {
-                        if (credentials.AWSAccessKeyId && credentials.AWSSecretKey) client = new AmazonSimpleWorkflowClient(credentials)
-                        else client = new AmazonSimpleWorkflowClient()
-                    }
-                    client.configuration = configuration
-                    client.endpoint = "swf.${region}.amazonaws.com"
-                    break
-            }
-            if (async) {
-                asyncClients[service][region] = client
-            } else {
-                clients[service][region] = client
-            }
+
+            client = Class.forName(className).newInstance(credentials)
+            client.endpoint = getClientEndpoint(service, endpoint, region)
+            client.configuration = configuration
+
+            clientsCache[service][region] = client
+        } else {
+            clientsCache[service][region]
         }
     }
 
+    private String getClientEndpoint(service, endpoint, region) {
+        switch(service) {
+            case 'S3':
+                if (region == 'us' || region == DEFAULT_REGION) {
+                    endpoint = "s3.amazonaws.com"
+                }
+                break
+            case ["SdbAsync", "Sdb"]:
+                if (region == 'us-east-1') {
+                    endpoint = "sdb.amazonaws.com"
+                }
+                break
+        }
+        
+        String.format(endpoint, region)
+    }
 }

--- a/test/unit/grails/plugin/awssdk/AmazonWebServiceTests.groovy
+++ b/test/unit/grails/plugin/awssdk/AmazonWebServiceTests.groovy
@@ -71,348 +71,602 @@ class AmazonWebServiceTests {
 
     void tearDown() {
     }
-    
+
     AmazonWebService getServiceWithCredentials() {
         def amazonWebService = new AmazonWebService()
-        
+
         grailsApplication.config.grails.plugin.awssdk.accessKey = "abcdefghi"
         grailsApplication.config.grails.plugin.awssdk.secretKey = "123456789"
-        
+
         amazonWebService.grailsApplication = grailsApplication
-        
+
         amazonWebService
     }
-    
+
     AmazonWebService getServiceWithoutCredentials() {
         def amazonWebService = new AmazonWebService()
-        
-        grailsApplication.config.grails.plugin.awssdk.accessKey = null
-        grailsApplication.config.grails.plugin.awssdk.secretKey = null
-        
+
         amazonWebService.grailsApplication = grailsApplication
-        
+
         amazonWebService
     }
 
-    void testAutoScalingClient() {
+    void testAutoScalingClientWithCredentials() {
         def amazonWebService = getServiceWithCredentials()
-        
+
         assert amazonWebService.getAutoScalingAsync().class == AmazonAutoScalingAsyncClient
+        assert amazonWebService.getAutoScalingAsync('eu-west-1').class == AmazonAutoScalingAsyncClient
         assert amazonWebService.getAutoScaling().class == AmazonAutoScalingClient
-        
-        amazonWebService = getServiceWithoutCredentials()
-        
+        assert amazonWebService.getAutoScaling('eu-west-1').class == AmazonAutoScalingClient
+    }
+
+    void testAutoScalingClientWithoutCredentials() {
+        def amazonWebService = getServiceWithoutCredentials()
+
         assert amazonWebService.getAutoScalingAsync().class == AmazonAutoScalingAsyncClient
+        assert amazonWebService.getAutoScalingAsync('eu-west-1').class == AmazonAutoScalingAsyncClient
         assert amazonWebService.getAutoScaling().class == AmazonAutoScalingClient
+        assert amazonWebService.getAutoScaling('eu-west-1').class == AmazonAutoScalingClient
     }
-    
-    void testCloudFormationClient() {
+
+    void testCloudFormationClientWithCredentials() {
         def amazonWebService = getServiceWithCredentials()
-        
+
         assert amazonWebService.getCloudFormationAsync().class == AmazonCloudFormationAsyncClient
+        assert amazonWebService.getCloudFormationAsync('eu-west-1').class == AmazonCloudFormationAsyncClient
         assert amazonWebService.getCloudFormation().class == AmazonCloudFormationClient
-        
-        amazonWebService = getServiceWithoutCredentials()
-        
+        assert amazonWebService.getCloudFormation('eu-west-1').class == AmazonCloudFormationClient
+    }
+
+    void testCloudFormationClientWithoutCredentials() {
+        def amazonWebService = getServiceWithoutCredentials()
+
         assert amazonWebService.getCloudFormationAsync().class == AmazonCloudFormationAsyncClient
+        assert amazonWebService.getCloudFormationAsync('eu-west-1').class == AmazonCloudFormationAsyncClient
         assert amazonWebService.getCloudFormation().class == AmazonCloudFormationClient
+        assert amazonWebService.getCloudFormation('eu-west-1').class == AmazonCloudFormationClient
     }
-    
-    void testCloudFrontClient() {
+
+    void testCloudFrontClientWithCredentials() {
         def amazonWebService = getServiceWithCredentials()
-        
+
         assert amazonWebService.getCloudFrontAsync().class == AmazonCloudFrontAsyncClient
+        shouldFail(MissingMethodException) {
+            amazonWebService.getCloudFrontAsync('eu-west-1')
+        }
         assert amazonWebService.getCloudFront().class == AmazonCloudFrontClient
-        
-        amazonWebService = getServiceWithoutCredentials()
-        
+        shouldFail(MissingMethodException) {
+            amazonWebService.getCloudFront('eu-west-1')
+        }
+    }
+
+    void testCloudFrontClientWithoutCredentials() {
+        def amazonWebService = getServiceWithoutCredentials()
+
         assert amazonWebService.getCloudFrontAsync().class == AmazonCloudFrontAsyncClient
+        shouldFail(MissingMethodException) {
+            amazonWebService.getCloudFrontAsync('eu-west-1')
+        }
         assert amazonWebService.getCloudFront().class == AmazonCloudFrontClient
+        shouldFail(MissingMethodException) {
+            amazonWebService.getCloudFront('eu-west-1')
+        }
     }
-    
-    void testCloudSearchClient() {
+
+    void testCloudSearchClientWithCredentials() {
         def amazonWebService = getServiceWithCredentials()
-        
+
         assert amazonWebService.getCloudSearchAsync().class == AmazonCloudSearchAsyncClient
+        assert amazonWebService.getCloudSearchAsync('eu-west-1').class == AmazonCloudSearchAsyncClient
         assert amazonWebService.getCloudSearch().class == AmazonCloudSearchClient
-        
-        amazonWebService = getServiceWithoutCredentials()
-        
+        assert amazonWebService.getCloudSearch('eu-west-1').class == AmazonCloudSearchClient
+    }
+
+    void testCloudSearchClientWithoutCredentials() {
+        def amazonWebService = getServiceWithoutCredentials()
+
         assert amazonWebService.getCloudSearchAsync().class == AmazonCloudSearchAsyncClient
+        assert amazonWebService.getCloudSearchAsync('eu-west-1').class == AmazonCloudSearchAsyncClient
         assert amazonWebService.getCloudSearch().class == AmazonCloudSearchClient
+        assert amazonWebService.getCloudSearch('eu-west-1').class == AmazonCloudSearchClient
     }
-    
-    void testCloudWatchClient() {
+
+    void testCloudWatchClientWithCredentials() {
         def amazonWebService = getServiceWithCredentials()
-        
+
         assert amazonWebService.getCloudWatchAsync().class == AmazonCloudWatchAsyncClient
+        assert amazonWebService.getCloudWatchAsync('eu-west-1').class == AmazonCloudWatchAsyncClient
         assert amazonWebService.getCloudWatch().class == AmazonCloudWatchClient
-        
-        amazonWebService = getServiceWithoutCredentials()
-        
+        assert amazonWebService.getCloudWatch('eu-west-1').class == AmazonCloudWatchClient
+    }
+
+    void testCloudWatchClientWithoutCredentials() {
+        def amazonWebService = getServiceWithoutCredentials()
+
         assert amazonWebService.getCloudWatchAsync().class == AmazonCloudWatchAsyncClient
+        assert amazonWebService.getCloudWatchAsync('eu-west-1').class == AmazonCloudWatchAsyncClient
         assert amazonWebService.getCloudWatch().class == AmazonCloudWatchClient
+        assert amazonWebService.getCloudWatch('eu-west-1').class == AmazonCloudWatchClient
     }
-    
-    void testDynamoDBClient() {
+
+    void testDynamoDBClientWithCredentials() {
         def amazonWebService = getServiceWithCredentials()
-        
+
         assert amazonWebService.getDynamoDBAsync().class == AmazonDynamoDBAsyncClient
+        assert amazonWebService.getDynamoDBAsync('eu-west-1').class == AmazonDynamoDBAsyncClient
         assert amazonWebService.getDynamoDB().class == AmazonDynamoDBClient
-        
-        amazonWebService = getServiceWithoutCredentials()
-        
-        assert amazonWebService.getDynamoDBAsync().class == AmazonDynamoDBAsyncClient
-        assert amazonWebService.getDynamoDB().class == AmazonDynamoDBClient
+        assert amazonWebService.getDynamoDB('eu-west-1').class == AmazonDynamoDBClient
     }
-    
-    void testEc2Client() {
+
+    void testDynamoDBClientWithoutCredentials() {
+        def amazonWebService = getServiceWithoutCredentials()
+
+        assert amazonWebService.getDynamoDBAsync().class == AmazonDynamoDBAsyncClient
+        assert amazonWebService.getDynamoDBAsync('eu-west-1').class == AmazonDynamoDBAsyncClient
+        assert amazonWebService.getDynamoDB().class == AmazonDynamoDBClient
+        assert amazonWebService.getDynamoDB('eu-west-1').class == AmazonDynamoDBClient
+    }
+
+    void testEc2ClientWithCredentials() {
         def amazonWebService = getServiceWithCredentials()
-        
+
         assert amazonWebService.getEc2Async().class == AmazonEC2AsyncClient
+        assert amazonWebService.getEc2Async('eu-west-1').class == AmazonEC2AsyncClient
         assert amazonWebService.getEc2().class == AmazonEC2Client
-        
-        amazonWebService = getServiceWithoutCredentials()
-        
-        assert amazonWebService.getEc2Async().class == AmazonEC2AsyncClient
-        assert amazonWebService.getEc2().class == AmazonEC2Client
+        assert amazonWebService.getEc2('eu-west-1').class == AmazonEC2Client
     }
-    
-    void testElasticBeanstalkClient() {
+
+    void testEc2ClientWithoutCredentials() {
+        def amazonWebService = getServiceWithoutCredentials()
+
+        assert amazonWebService.getEc2Async().class == AmazonEC2AsyncClient
+        assert amazonWebService.getEc2Async('eu-west-1').class == AmazonEC2AsyncClient
+        assert amazonWebService.getEc2().class == AmazonEC2Client
+        assert amazonWebService.getEc2('eu-west-1').class == AmazonEC2Client
+    }
+
+    void testElasticBeanstalkClientWithCredentials() {
         def amazonWebService = getServiceWithCredentials()
 
         assert amazonWebService.getElasticBeanstalkAsync().class == AWSElasticBeanstalkAsyncClient
+        assert amazonWebService.getElasticBeanstalkAsync('eu-west-1').class == AWSElasticBeanstalkAsyncClient
         assert amazonWebService.getElasticBeanstalk().class == AWSElasticBeanstalkClient
-        
-        amazonWebService = getServiceWithoutCredentials()
-        
+        assert amazonWebService.getElasticBeanstalk('eu-west-1').class == AWSElasticBeanstalkClient
+    }
+
+    void testElasticBeanstalkClientWithoutCredentials() {
+        def amazonWebService = getServiceWithoutCredentials()
+
         assert amazonWebService.getElasticBeanstalkAsync().class == AWSElasticBeanstalkAsyncClient
+        assert amazonWebService.getElasticBeanstalkAsync('eu-west-1').class == AWSElasticBeanstalkAsyncClient
         assert amazonWebService.getElasticBeanstalk().class == AWSElasticBeanstalkClient
+        assert amazonWebService.getElasticBeanstalk('eu-west-1').class == AWSElasticBeanstalkClient
     }
-    
-    void testElastiCacheClient() {
+
+    void testElastiCacheClientWithCredentials() {
         def amazonWebService = getServiceWithCredentials()
 
         assert amazonWebService.getElastiCacheAsync().class == AmazonElastiCacheAsyncClient
+        assert amazonWebService.getElastiCacheAsync('eu-west-1').class == AmazonElastiCacheAsyncClient
         assert amazonWebService.getElastiCache().class == AmazonElastiCacheClient
-        
-        amazonWebService = getServiceWithoutCredentials()
-        
+        assert amazonWebService.getElastiCache('eu-west-1').class == AmazonElastiCacheClient
+    }
+
+    void testElastiCacheClientWithoutCredentials() {
+        def amazonWebService = getServiceWithoutCredentials()
+
         assert amazonWebService.getElastiCacheAsync().class == AmazonElastiCacheAsyncClient
+        assert amazonWebService.getElastiCacheAsync('eu-west-1').class == AmazonElastiCacheAsyncClient
         assert amazonWebService.getElastiCache().class == AmazonElastiCacheClient
+        assert amazonWebService.getElastiCache('eu-west-1').class == AmazonElastiCacheClient
     }
-    
-    void testElbClient() {
+
+    void testElasticLoadBalancingClientWithCredentials() {
         def amazonWebService = getServiceWithCredentials()
 
-        assert amazonWebService.getElbAsync().class == AmazonElasticLoadBalancingAsyncClient
-        assert amazonWebService.getElb().class == AmazonElasticLoadBalancingClient
-        
-        amazonWebService = getServiceWithoutCredentials()
-        
-        assert amazonWebService.getElbAsync().class == AmazonElasticLoadBalancingAsyncClient
-        assert amazonWebService.getElb().class == AmazonElasticLoadBalancingClient
+        assert amazonWebService.getElasticLoadBalancingAsync().class == AmazonElasticLoadBalancingAsyncClient
+        assert amazonWebService.getElasticLoadBalancingAsync('eu-west-1').class == AmazonElasticLoadBalancingAsyncClient
+        assert amazonWebService.getElasticLoadBalancing().class == AmazonElasticLoadBalancingClient
+        assert amazonWebService.getElasticLoadBalancing('eu-west-1').class == AmazonElasticLoadBalancingClient
     }
-    
-    void testElasticMapReduceClient() {
+
+    void testElasticLoadBalancingClientWithoutCredentials() {
+        def amazonWebService = getServiceWithoutCredentials()
+
+        assert amazonWebService.getElasticLoadBalancingAsync().class == AmazonElasticLoadBalancingAsyncClient
+        assert amazonWebService.getElasticLoadBalancingAsync('eu-west-1').class == AmazonElasticLoadBalancingAsyncClient
+        assert amazonWebService.getElasticLoadBalancing().class == AmazonElasticLoadBalancingClient
+        assert amazonWebService.getElasticLoadBalancing('eu-west-1').class == AmazonElasticLoadBalancingClient
+    }
+
+    void testElasticMapReduceClientWithCredentials() {
         def amazonWebService = getServiceWithCredentials()
 
         assert amazonWebService.getElasticMapReduceAsync().class == AmazonElasticMapReduceAsyncClient
+        assert amazonWebService.getElasticMapReduceAsync('eu-west-1').class == AmazonElasticMapReduceAsyncClient
         assert amazonWebService.getElasticMapReduce().class == AmazonElasticMapReduceClient
-        
-        amazonWebService = getServiceWithoutCredentials()
-        
+        assert amazonWebService.getElasticMapReduce('eu-west-1').class == AmazonElasticMapReduceClient
+    }
+
+    void testElasticMapReduceClientWithoutCredentials() {
+        def amazonWebService = getServiceWithoutCredentials()
+
         assert amazonWebService.getElasticMapReduceAsync().class == AmazonElasticMapReduceAsyncClient
+        assert amazonWebService.getElasticMapReduceAsync('eu-west-1').class == AmazonElasticMapReduceAsyncClient
         assert amazonWebService.getElasticMapReduce().class == AmazonElasticMapReduceClient
+        assert amazonWebService.getElasticMapReduce('eu-west-1').class == AmazonElasticMapReduceClient
     }
-    
-    void testElasticTranscoderClient() {
+
+    void testElasticTranscoderClientWithCredentials() {
         def amazonWebService = getServiceWithCredentials()
 
         assert amazonWebService.getElasticTranscoderAsync().class == AmazonElasticTranscoderAsyncClient
+        assert amazonWebService.getElasticTranscoderAsync('eu-west-1').class == AmazonElasticTranscoderAsyncClient
         assert amazonWebService.getElasticTranscoder().class == AmazonElasticTranscoderClient
-        
-        amazonWebService = getServiceWithoutCredentials()
-        
+        assert amazonWebService.getElasticTranscoder('eu-west-1').class == AmazonElasticTranscoderClient
+    }
+
+    void testElasticTranscoderClientWithoutCredentials() {
+        def amazonWebService = getServiceWithoutCredentials()
+
         assert amazonWebService.getElasticTranscoderAsync().class == AmazonElasticTranscoderAsyncClient
+        assert amazonWebService.getElasticTranscoderAsync('eu-west-1').class == AmazonElasticTranscoderAsyncClient
         assert amazonWebService.getElasticTranscoder().class == AmazonElasticTranscoderClient
+        assert amazonWebService.getElasticTranscoder('eu-west-1').class == AmazonElasticTranscoderClient
     }
-    
-    void testGlacierClient() {
+
+    void testGlacierClientWithCredentials() {
         def amazonWebService = getServiceWithCredentials()
 
         assert amazonWebService.getGlacierAsync().class == AmazonGlacierAsyncClient
+        assert amazonWebService.getGlacierAsync('eu-west-1').class == AmazonGlacierAsyncClient
         assert amazonWebService.getGlacier().class == AmazonGlacierClient
-        
-        amazonWebService = getServiceWithoutCredentials()
-        
+        assert amazonWebService.getGlacier('eu-west-1').class == AmazonGlacierClient
+    }
+
+    void testGlacierClientWithoutCredentials() {
+        def amazonWebService = getServiceWithoutCredentials()
+
         assert amazonWebService.getGlacierAsync().class == AmazonGlacierAsyncClient
+        assert amazonWebService.getGlacierAsync('eu-west-1').class == AmazonGlacierAsyncClient
         assert amazonWebService.getGlacier().class == AmazonGlacierClient
+        assert amazonWebService.getGlacier('eu-west-1').class == AmazonGlacierClient
     }
-    
-    void testIamClient() {
+
+    void testIamClientWithCredentials() {
         def amazonWebService = getServiceWithCredentials()
 
         assert amazonWebService.getIamAsync().class == AmazonIdentityManagementAsyncClient
+        shouldFail(MissingMethodException) {
+            amazonWebService.getIamAsync('eu-west-1')
+        }
         assert amazonWebService.getIam().class == AmazonIdentityManagementClient
-        
-        amazonWebService = getServiceWithoutCredentials()
-        
+        shouldFail(MissingMethodException) {
+            amazonWebService.getIam('eu-west-1')
+        }
+    }
+
+    void testIamClientWithoutCredentials() {
+        def amazonWebService = getServiceWithoutCredentials()
+
         assert amazonWebService.getIamAsync().class == AmazonIdentityManagementAsyncClient
+        shouldFail(MissingMethodException) {
+            amazonWebService.getIamAsync('eu-west-1')
+        }
         assert amazonWebService.getIam().class == AmazonIdentityManagementClient
+        shouldFail(MissingMethodException) {
+            amazonWebService.getIam('eu-west-1')
+        }
     }
-    
-    void testImportExportClient() {
+
+    void testImportExportClientWithCredentials() {
         def amazonWebService = getServiceWithCredentials()
 
         assert amazonWebService.getImportExportAsync().class == AmazonImportExportAsyncClient
+        shouldFail(MissingMethodException) {
+            amazonWebService.getImportExportAsync('eu-west-1')
+        }
         assert amazonWebService.getImportExport().class == AmazonImportExportClient
-        
-        amazonWebService = getServiceWithoutCredentials()
-        
+        shouldFail(MissingMethodException) {
+            amazonWebService.getImportExport('eu-west-1')
+        }
+    }
+
+    void testImportExportClientWithoutCredentials() {
+        def amazonWebService = getServiceWithoutCredentials()
+
         assert amazonWebService.getImportExportAsync().class == AmazonImportExportAsyncClient
+        shouldFail(MissingMethodException) {
+            amazonWebService.getImportExportAsync('eu-west-1')
+        }
         assert amazonWebService.getImportExport().class == AmazonImportExportClient
+        shouldFail(MissingMethodException) {
+            amazonWebService.getImportExport('eu-west-1')
+        }
     }
-    
-    void testOpsWorksAsync() {
+
+    void testOpsWorksAsyncWithCredentials() {
         def amazonWebService = getServiceWithCredentials()
-        
+
         assert amazonWebService.getOpsWorksAsync().class == AWSOpsWorksAsyncClient
+        shouldFail(MissingMethodException) {
+            amazonWebService.getOpsWorksAsync('eu-west-1')
+        }
         assert amazonWebService.getOpsWorks().class == AWSOpsWorksClient
-        
-        amazonWebService = getServiceWithoutCredentials()
-        
-        assert amazonWebService.getOpsWorksAsync().class == AWSOpsWorksAsyncClient
-        assert amazonWebService.getOpsWorks().class == AWSOpsWorksClient
+        shouldFail(MissingMethodException) {
+            amazonWebService.getOpsWorks('eu-west-1')
+        }
     }
-    
-    void testRdsClient() {
+
+    void testOpsWorksAsyncWithoutCredentials() {
+        def amazonWebService = getServiceWithoutCredentials()
+
+        assert amazonWebService.getOpsWorksAsync().class == AWSOpsWorksAsyncClient
+        shouldFail(MissingMethodException) {
+            amazonWebService.getOpsWorksAsync('eu-west-1')
+        }
+        assert amazonWebService.getOpsWorks().class == AWSOpsWorksClient
+        shouldFail(MissingMethodException) {
+            amazonWebService.getOpsWorks('eu-west-1')
+        }
+    }
+
+    void testRdsClientWithCredentials() {
         def amazonWebService = getServiceWithCredentials()
 
         assert amazonWebService.getRdsAsync().class == AmazonRDSAsyncClient
+        assert amazonWebService.getRdsAsync('eu-west-1').class == AmazonRDSAsyncClient
         assert amazonWebService.getRds().class == AmazonRDSClient
-        
-        amazonWebService = getServiceWithoutCredentials()
-        
+        assert amazonWebService.getRds('eu-west-1').class == AmazonRDSClient
+    }
+
+    void testRdsClientWithoutCredentials() {
+        def amazonWebService = getServiceWithoutCredentials()
+
         assert amazonWebService.getRdsAsync().class == AmazonRDSAsyncClient
+        assert amazonWebService.getRdsAsync('eu-west-1').class == AmazonRDSAsyncClient
         assert amazonWebService.getRds().class == AmazonRDSClient
+        assert amazonWebService.getRds('eu-west-1').class == AmazonRDSClient
     }
-    
-    void testRedshiftClient() {
+
+    void testRedshiftClientWithCredentials() {
         def amazonWebService = getServiceWithCredentials()
-        
+
         assert amazonWebService.getRedshiftAsync().class == AmazonRedshiftAsyncClient
+        shouldFail(MissingMethodException) {
+            amazonWebService.getRedshiftAsync('eu-west-1')
+        }
         assert amazonWebService.getRedshift().class == AmazonRedshiftClient
-        
-        amazonWebService = getServiceWithoutCredentials()
-        
-        assert amazonWebService.getRedshiftAsync().class == AmazonRedshiftAsyncClient
-        assert amazonWebService.getRedshift().class == AmazonRedshiftClient
+        shouldFail(MissingMethodException) {
+            amazonWebService.getRedshift('eu-west-1')
+        }
     }
-    
-    void testRoute53Client() {
+
+    void testRedshiftClientWithoutCredentials() {
+        def amazonWebService = getServiceWithoutCredentials()
+
+        assert amazonWebService.getRedshiftAsync().class == AmazonRedshiftAsyncClient
+        shouldFail(MissingMethodException) {
+            amazonWebService.getRedshiftAsync('eu-west-1')
+        }
+        assert amazonWebService.getRedshift().class == AmazonRedshiftClient
+        shouldFail(MissingMethodException) {
+            amazonWebService.getRedshift('eu-west-1')
+        }
+    }
+
+    void testRoute53ClientWithCredentials() {
         def amazonWebService = getServiceWithCredentials()
 
         assert amazonWebService.getRoute53Async().class == AmazonRoute53AsyncClient
+        shouldFail(MissingMethodException) {
+            amazonWebService.getRoute53Async('eu-west-1')
+        }
         assert amazonWebService.getRoute53().class == AmazonRoute53Client
-        
-        amazonWebService = getServiceWithoutCredentials()
-        
+        shouldFail(MissingMethodException) {
+            amazonWebService.getRoute53('eu-west-1')
+        }
+    }
+
+    void testRoute53ClientWithoutCredentials() {
+        def amazonWebService = getServiceWithoutCredentials()
+
         assert amazonWebService.getRoute53Async().class == AmazonRoute53AsyncClient
+        shouldFail(MissingMethodException) {
+            amazonWebService.getRoute53Async('eu-west-1')
+        }
         assert amazonWebService.getRoute53().class == AmazonRoute53Client
+        shouldFail(MissingMethodException) {
+            amazonWebService.getRoute53('eu-west-1')
+        }
     }
-    
-    void testS3Client() {
+
+    void testS3ClientWithCredentials() {
         def amazonWebService = getServiceWithCredentials()
 
-        shouldFail(Exception) {
+        shouldFail(MissingMethodException) {
             amazonWebService.getS3Async()
         }
-        assert amazonWebService.getS3().class == AmazonS3Client
-        
-        amazonWebService = getServiceWithoutCredentials()
-        
-        shouldFail(Exception) {
-            amazonWebService.getS3Async()
+        shouldFail(MissingMethodException) {
+            amazonWebService.getS3Async('eu-west-1')
         }
         assert amazonWebService.getS3().class == AmazonS3Client
+        assert amazonWebService.getS3('eu-west-1').class == AmazonS3Client
     }
-    
-    void testSdbClient() {
+
+    void testS3ClientWithoutCredentials() {
+        def amazonWebService = getServiceWithoutCredentials()
+
+        shouldFail(MissingMethodException) {
+            amazonWebService.getS3Async()
+        }
+        shouldFail(MissingMethodException) {
+            amazonWebService.getS3Async('eu-west-1')
+        }
+        assert amazonWebService.getS3().class == AmazonS3Client
+        assert amazonWebService.getS3('eu-west-1').class == AmazonS3Client
+    }
+
+    void testSdbClientWithCredentials() {
         def amazonWebService = getServiceWithCredentials()
 
         assert amazonWebService.getSdbAsync().class == AmazonSimpleDBAsyncClient
+        assert amazonWebService.getSdbAsync('eu-west-1').class == AmazonSimpleDBAsyncClient
         assert amazonWebService.getSdb().class == AmazonSimpleDBClient
-        
-        amazonWebService = getServiceWithoutCredentials()
-        
+        assert amazonWebService.getSdb('eu-west-1').class == AmazonSimpleDBClient
+    }
+
+    void testSdbClientWithoutCredentials() {
+        def amazonWebService = getServiceWithoutCredentials()
+
         assert amazonWebService.getSdbAsync().class == AmazonSimpleDBAsyncClient
+        assert amazonWebService.getSdbAsync('eu-west-1').class == AmazonSimpleDBAsyncClient
         assert amazonWebService.getSdb().class == AmazonSimpleDBClient
+        assert amazonWebService.getSdb('eu-west-1').class == AmazonSimpleDBClient
     }
-    
-    void testSesClient() {
+
+    void testSesClientWithCredentials() {
         def amazonWebService = getServiceWithCredentials()
 
         assert amazonWebService.getSesAsync().class == AmazonSimpleEmailServiceAsyncClient
+        assert amazonWebService.getSesAsync('eu-west-1').class == AmazonSimpleEmailServiceAsyncClient
         assert amazonWebService.getSes().class == AmazonSimpleEmailServiceClient
-        
-        amazonWebService = getServiceWithoutCredentials()
-        
+        assert amazonWebService.getSes('eu-west-1').class == AmazonSimpleEmailServiceClient
+    }
+
+    void testSesClientWithoutCredentials() {
+        def amazonWebService = getServiceWithoutCredentials()
+
         assert amazonWebService.getSesAsync().class == AmazonSimpleEmailServiceAsyncClient
+        assert amazonWebService.getSesAsync('eu-west-1').class == AmazonSimpleEmailServiceAsyncClient
         assert amazonWebService.getSes().class == AmazonSimpleEmailServiceClient
+        assert amazonWebService.getSes('eu-west-1').class == AmazonSimpleEmailServiceClient
     }
-    
-    void testSnsClient() {
+
+    void testSnsClientWithCredentials() {
         def amazonWebService = getServiceWithCredentials()
 
         assert amazonWebService.getSnsAsync().class == AmazonSNSAsyncClient
+        assert amazonWebService.getSnsAsync('eu-west-1').class == AmazonSNSAsyncClient
         assert amazonWebService.getSns().class == AmazonSNSClient
-        
-        amazonWebService = getServiceWithoutCredentials()
-        
+        assert amazonWebService.getSns('eu-west-1').class == AmazonSNSClient
+    }
+
+    void testSnsClientWithoutCredentials() {
+        def amazonWebService = getServiceWithoutCredentials()
+
         assert amazonWebService.getSnsAsync().class == AmazonSNSAsyncClient
+        assert amazonWebService.getSnsAsync('eu-west-1').class == AmazonSNSAsyncClient
         assert amazonWebService.getSns().class == AmazonSNSClient
+        assert amazonWebService.getSns('eu-west-1').class == AmazonSNSClient
     }
-    
-    void testSqsClient() {
+
+    void testSqsClientWithCredentials() {
         def amazonWebService = getServiceWithCredentials()
 
         assert amazonWebService.getSqsAsync().class == AmazonSQSAsyncClient
+        assert amazonWebService.getSqsAsync('eu-west-1').class == AmazonSQSAsyncClient
         assert amazonWebService.getSqs().class == AmazonSQSClient
-        
-        amazonWebService = getServiceWithoutCredentials()
-        
+        assert amazonWebService.getSqs('eu-west-1').class == AmazonSQSClient
+    }
+
+    void testSqsClientWithoutCredentials() {
+        def amazonWebService = getServiceWithoutCredentials()
+
         assert amazonWebService.getSqsAsync().class == AmazonSQSAsyncClient
+        assert amazonWebService.getSqsAsync('eu-west-1').class == AmazonSQSAsyncClient
         assert amazonWebService.getSqs().class == AmazonSQSClient
+        assert amazonWebService.getSqs('eu-west-1').class == AmazonSQSClient
     }
-    
-    void testStorageGatewayClient() {
+
+    void testStorageGatewayClientWithCredentials() {
         def amazonWebService = getServiceWithCredentials()
 
         assert amazonWebService.getStorageGatewayAsync().class == AWSStorageGatewayAsyncClient
+        assert amazonWebService.getStorageGatewayAsync('eu-west-1').class == AWSStorageGatewayAsyncClient
         assert amazonWebService.getStorageGateway().class == AWSStorageGatewayClient
-        
-        amazonWebService = getServiceWithoutCredentials()
+        assert amazonWebService.getStorageGateway('eu-west-1').class == AWSStorageGatewayClient
+    }
+
+    void testStorageGatewayClientWithoutCredentials() {
+        def amazonWebService = getServiceWithoutCredentials()
         
         assert amazonWebService.getStorageGatewayAsync().class == AWSStorageGatewayAsyncClient
+        assert amazonWebService.getStorageGatewayAsync('eu-west-1').class == AWSStorageGatewayAsyncClient
         assert amazonWebService.getStorageGateway().class == AWSStorageGatewayClient
+        assert amazonWebService.getStorageGateway('eu-west-1').class == AWSStorageGatewayClient
     }
-    
-    void testSwfClient() {
+
+    void testSwfClientWithCredentials() {
         def amazonWebService = getServiceWithCredentials()
 
         assert amazonWebService.getSwfAsync().class == AmazonSimpleWorkflowAsyncClient
+        assert amazonWebService.getSwfAsync('eu-west-1').class == AmazonSimpleWorkflowAsyncClient
         assert amazonWebService.getSwf().class == AmazonSimpleWorkflowClient
-        
-        amazonWebService = getServiceWithoutCredentials()
-        
-        assert amazonWebService.getSwfAsync().class == AmazonSimpleWorkflowAsyncClient
-        assert amazonWebService.getSwf().class == AmazonSimpleWorkflowClient
+        assert amazonWebService.getSwf('eu-west-1').class == AmazonSimpleWorkflowClient
     }
-    
+
+    void testSwfClientWithoutCredentials() {
+        def amazonWebService = getServiceWithoutCredentials()
+
+        assert amazonWebService.getSwfAsync().class == AmazonSimpleWorkflowAsyncClient
+        assert amazonWebService.getSwfAsync('eu-west-1').class == AmazonSimpleWorkflowAsyncClient
+        assert amazonWebService.getSwf().class == AmazonSimpleWorkflowClient
+        assert amazonWebService.getSwf('eu-west-1').class == AmazonSimpleWorkflowClient
+    }
+
     void testTransferManager() {
         def amazonWebService = getServiceWithCredentials()
 
         assert amazonWebService.getTransferManager().class == TransferManager
+        assert amazonWebService.getTransferManager('eu-west-1').class == TransferManager
+    }
+
+    void testAsyncClientCache() {
+        def amazonWebService = getServiceWithCredentials()
+
+        def service1
+        def service2
+        def otherService
+        def otherServiceType
+        def otherRegion1
+        def otherRegion2
+
+        // check if the cache returns the same object if requested twice, 
+        // also make sure other calls and regions don't corrupt the cache
+        service1 = amazonWebService.getSesAsync()
+        otherRegion1 = amazonWebService.getSesAsync('eu-west-1')
+        otherService = amazonWebService.getSwfAsync()
+        otherServiceType = amazonWebService.getSes()
+        service2 = amazonWebService.getSesAsync()
+        otherRegion2 = amazonWebService.getSesAsync('eu-west-1')
+        assert service1 == service2
+        assert otherRegion1 == otherRegion2
+        assert service1 != otherService
+        assert service1 != otherServiceType
+        assert service1 != otherRegion1
+    }
+
+    void testSyncClientCache() {
+        def amazonWebService = getServiceWithCredentials()
+
+        def service1
+        def service2
+        def otherService
+        def otherServiceType
+        def otherRegion1
+        def otherRegion2
+
+        service1 = amazonWebService.getSes()
+        otherRegion1 = amazonWebService.getSes('eu-west-1')
+        otherService = amazonWebService.getSwf()
+        otherServiceType = amazonWebService.getSesAsync()
+        service2 = amazonWebService.getSes()
+        otherRegion2 = amazonWebService.getSes('eu-west-1')
+        assert service1 == service2
+        assert otherRegion1 == otherRegion2
+        assert service1 != otherService
+        assert service1 != otherServiceType
+        assert service1 != otherRegion1
     }
 }


### PR DESCRIPTION
Added unit test for AmazonWebservice and fixed a few bugs/missing methods I found with it:
- added getElasticTranscoderAsync
- added getGlacierAsync
- getRedshift would return the asynchronous client when credentials were given

Renamed getElb(Async) to getElasticLoadBalancing(Async) to be more consistent, this might be a breaking change for some, but the docs were already using this name.

The check if a client was in the (async)clients Map already was not correct, so every request a new client was created, this is fixed now.

Refactored the service to have less duplicate code.
We could take this a step further by using the methodMissing concept, but the available methods will not be exposed anymore. I've done this in the refactor2 branch: https://github.com/MGotink/grails-aws-sdk/tree/refactor2
