### PR TITLE
Fix to enable s3 work with 'us' region

### DIFF
--- a/grails-app/services/grails/plugin/awssdk/AmazonWebService.groovy
+++ b/grails-app/services/grails/plugin/awssdk/AmazonWebService.groovy
@@ -406,12 +406,12 @@ class AmazonWebService {
 
     private String getClientEndpoint(service, endpoint, region) {
         switch(service) {
-            case 'S3':
+            case 's3':
                 if (region == 'us' || region == DEFAULT_REGION) {
                     endpoint = "s3.amazonaws.com"
                 }
                 break
-            case ["SdbAsync", "Sdb"]:
+            case ["SdbAsync", "sdb"]:
                 if (region == 'us-east-1') {
                     endpoint = "sdb.amazonaws.com"
                 }


### PR DESCRIPTION
When using s3 with 'us' region is redirecting to bucket.s3-us.amazonaws.com which is not valid, and instead use the s3.amazonaws.com url.
