### PR TITLE
Add support for Security Token Service

### DIFF
--- a/grails-app/services/grails/plugin/awssdk/AmazonWebService.groovy
+++ b/grails-app/services/grails/plugin/awssdk/AmazonWebService.groovy
@@ -48,6 +48,8 @@ import com.amazonaws.services.route53.AmazonRoute53AsyncClient
 import com.amazonaws.services.route53.AmazonRoute53Client
 import com.amazonaws.services.s3.AmazonS3Client
 import com.amazonaws.services.s3.transfer.TransferManager
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceAsyncClient
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClient
 import com.amazonaws.services.simpledb.AmazonSimpleDBAsyncClient
 import com.amazonaws.services.simpledb.AmazonSimpleDBClient
 import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceAsyncClient
@@ -93,6 +95,7 @@ class AmazonWebService {
         'route53':                  [className: 'com.amazonaws.services.route53.AmazonRoute53Client'],
         's3':                       [className: 'com.amazonaws.services.s3.AmazonS3Client'],
         'sdb':                      [className: 'com.amazonaws.services.simpledb.AmazonSimpleDBClient'],
+        'sts':                      [className: 'com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClient'],
         'ses':                      [className: 'com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClient'],
         'swf':                      [className: 'com.amazonaws.services.simpleworkflow.AmazonSimpleWorkflowClient'],
         'sns':                      [className: 'com.amazonaws.services.sns.AmazonSNSClient'],
@@ -254,6 +257,14 @@ class AmazonWebService {
 
     AmazonS3Client getS3(String regionName = '') {
         getServiceClient('s3', regionName) as AmazonS3Client
+    }
+
+    AWSSecurityTokenServiceClient getSts(String regionName = '') {
+        getServiceClient('sts', regionName) as AWSSecurityTokenServiceClient
+    }
+
+    AWSSecurityTokenServiceAsyncClient getStsAsync(String regionName = '') {
+        getServiceClient('sts', regionName, true) as AWSSecurityTokenServiceAsyncClient
     }
 
     AmazonSimpleDBAsyncClient getSdbAsync(String regionName = '') {

--- a/test/unit/grails/plugin/awssdk/AmazonWebServiceTests.groovy
+++ b/test/unit/grails/plugin/awssdk/AmazonWebServiceTests.groovy
@@ -58,6 +58,8 @@ import com.amazonaws.services.sqs.AmazonSQSAsyncClient
 import com.amazonaws.services.sqs.AmazonSQSClient
 import com.amazonaws.services.storagegateway.AWSStorageGatewayAsyncClient
 import com.amazonaws.services.storagegateway.AWSStorageGatewayClient
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceAsyncClient
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClient
 
 /**
  * See the API for {@link grails.test.mixin.support.GrailsUnitTestMixin} for usage instructions
@@ -649,6 +651,26 @@ class AmazonWebServiceTests {
         assert amazonWebService.getStorageGateway().class == AWSStorageGatewayClient
         assert amazonWebService.getStorageGateway('eu-west-1').class == AWSStorageGatewayClient
         assert amazonWebService.getStorageGateway('eu-west-1').endpoint.toString() == 'https://storagegateway.eu-west-1.amazonaws.com'
+    }
+
+    void testStsClientWithCredentials() {
+        def amazonWebService = getServiceWithCredentials()
+
+        assert amazonWebService.getStsAsync().class == AWSSecurityTokenServiceAsyncClient
+        assert amazonWebService.getStsAsync('eu-west-1').class == AWSSecurityTokenServiceAsyncClient
+        assert amazonWebService.getSts().class == AWSSecurityTokenServiceClient
+        assert amazonWebService.getSts('eu-west-1').class == AWSSecurityTokenServiceClient
+        assert amazonWebService.getSts('eu-west-1').endpoint.toString() == 'https://sts.amazonaws.com'
+    }
+
+    void testStsClientWithoutCredentials() {
+        def amazonWebService = getServiceWithoutCredentials()
+
+        assert amazonWebService.getStsAsync().class == AWSSecurityTokenServiceAsyncClient
+        assert amazonWebService.getStsAsync('eu-west-1').class == AWSSecurityTokenServiceAsyncClient
+        assert amazonWebService.getSts().class == AWSSecurityTokenServiceClient
+        assert amazonWebService.getSts('eu-west-1').class == AWSSecurityTokenServiceClient
+        assert amazonWebService.getSts('eu-west-1').endpoint.toString() == 'https://sts.amazonaws.com'
     }
 
     void testSwfClientWithCredentials() {


### PR DESCRIPTION
The plugin doesn't currently support the AWS Security Token Service API.
