### PR TITLE
Make AmazonWebService non-transactional

### DIFF
--- a/grails-app/services/grails/plugin/awssdk/AmazonWebService.groovy
+++ b/grails-app/services/grails/plugin/awssdk/AmazonWebService.groovy
@@ -64,6 +64,8 @@ import com.amazonaws.services.storagegateway.AWSStorageGatewayClient
 class AmazonWebService {
 
     static final String DEFAULT_REGION = 'us-east-1'
+    
+    static transactional = false
 
     def grailsApplication
 


### PR DESCRIPTION
AmazonWebService should not be transactional since no hibernate session is needed. It also requires transactionManager bean that is not available without hibernate plugin - that's a problem mainly in plugin that depends on this service but not on hibernate plugin.
