### PR TITLE
chore: upgrade aws-java-sdk to 1.11.714 to enable IMDSv2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 version=2.4.5
-awsJavaSdkVersion=1.11.592
+awsJavaSdkVersion=1.11.714
 awsKinesisClientVersion=1.10.0
 gradleWrapperVersion=5.5.1
 grailsVersion=4.0.0


### PR DESCRIPTION
upgrade aws-java-sdk to 1.11.714 in order to enable IMDSv2 introduced in the version `1.11.678`