### PR TITLE
DKIM fix for sendEmailWithAttachment.

### DIFF
--- a/groovy-aws-sdk-ses/src/main/groovy/com/agorapulse/awssdk/ses/AwsSesMailer.groovy
+++ b/groovy-aws-sdk-ses/src/main/groovy/com/agorapulse/awssdk/ses/AwsSesMailer.groovy
@@ -77,7 +77,9 @@ class AwsSesMailer {
 
         Session session = Session.getInstance(new Properties())
         MimeMessage mimeMessage = new MimeMessage(session)
-        mimeMessage.setFrom(new InternetAddress(transactionalEmail.sourceEmail))
+        if (transactionalEmail.sourceEmail) {
+            mimeMessage.setFrom(new InternetAddress(transactionalEmail.sourceEmail))
+        }
         if (transactionalEmail.replyToEmail) {
             InternetAddress[] replyToArray = [new InternetAddress(transactionalEmail.replyToEmail)]
             mimeMessage.setReplyTo(replyToArray)

--- a/groovy-aws-sdk-ses/src/main/groovy/com/agorapulse/awssdk/ses/AwsSesMailer.groovy
+++ b/groovy-aws-sdk-ses/src/main/groovy/com/agorapulse/awssdk/ses/AwsSesMailer.groovy
@@ -20,6 +20,7 @@ import javax.activation.DataHandler
 import javax.activation.DataSource
 import javax.mail.BodyPart
 import javax.mail.Session
+import javax.mail.internet.InternetAddress
 import javax.mail.internet.MimeBodyPart
 import javax.mail.internet.MimeMessage
 import javax.mail.internet.MimeMultipart
@@ -76,6 +77,14 @@ class AwsSesMailer {
 
         Session session = Session.getInstance(new Properties())
         MimeMessage mimeMessage = new MimeMessage(session)
+        mimeMessage.setFrom(new InternetAddress(transactionalEmail.sourceEmail))
+        if (transactionalEmail.replyToEmail) {
+            InternetAddress[] replyToArray = [new InternetAddress(transactionalEmail.replyToEmail)]
+            mimeMessage.setReplyTo(replyToArray)
+        }
+        transactionalEmail.recipients.each { recipient ->
+            mimeMessage.addRecipients(javax.mail.Message.RecipientType.TO, new InternetAddress(recipient))
+        }
         def subject = transactionalEmail.subject
         mimeMessage.setSubject(subject)
         MimeMultipart mimeMultipart = new MimeMultipart()

--- a/groovy-aws-sdk-ses/src/test/groovy/com/agorapulse/awssdk/ses/AwsSesMailerSpec.groovy
+++ b/groovy-aws-sdk-ses/src/test/groovy/com/agorapulse/awssdk/ses/AwsSesMailerSpec.groovy
@@ -77,7 +77,6 @@ class AwsSesMailerSpec extends Specification {
         awsSesMailer.mailWithAttachment {
             subject subjectStr
             htmlBody '<p>This is an example body</p>'
-            to System.getProperty('TEST_INBOX_EMAIL')
             from System.getProperty('TEST_FROM_EMAIL')
             attachment {
                 filepath '/temp/virus.exe'


### PR DESCRIPTION
Add the the From:, Reply-to, and To: headers to sendEmailWithAttachment. The lack of a From: header breaks DKIM.